### PR TITLE
Update gmail search to work with current imapclient

### DIFF
--- a/lostphotosfound/server.py
+++ b/lostphotosfound/server.py
@@ -113,9 +113,9 @@ class Server:
         # that's why we only support gmail
         # for other mail services we'd have to translate the custom
         # search to actual IMAP queries, thus no X-GM-RAW cookie for us
-        criteria = 'X-GM-RAW "has:attachment filename:(%s)"' % (mimelist)
+        criteria = 'has:attachment filename:(%s)' % (mimelist)
         try:
-            messages = self._server.search([criteria])
+            messages = self._server.gmail_search(criteria)
         except:
             raise Exception('Search criteria returned a failure, it must be a valid gmail search')
 


### PR DESCRIPTION
Current imapclient wants gmail X-GM-RAW searches to be performed using
gmail_search('bla') instead of search('X-GM-RAW "bla"). Update our code
accordingly.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>