### PR TITLE
Add user-defined search parameters

### DIFF
--- a/lostphotosfound/server.py
+++ b/lostphotosfound/server.py
@@ -32,7 +32,7 @@ class Server:
     fetch all attachments of the mails matching the criteria and
     save them locally with a timestamp
     """
-    def __init__(self, host, username, password, debug=False):
+    def __init__(self, host, username, password, search='', debug=False):
         """
         Server class __init__ which expects an IMAP host to connect to
 
@@ -60,6 +60,9 @@ class Server:
         hashes = '.hashes_%s' % (username)
         hashes = os.path.join(_app_folder(), hashes)
         self._hashes = shelve.open(hashes, writeback=True)
+
+	# additional email filtering using Gmail search syntax
+	self._search = search
 
         self._username = username
         self._login(username, password)
@@ -114,6 +117,11 @@ class Server:
         # for other mail services we'd have to translate the custom
         # search to actual IMAP queries, thus no X-GM-RAW cookie for us
         criteria = 'has:attachment filename:(%s)' % (mimelist)
+
+        # add user-defined search criteria
+        if self._search:
+            criteria = '{} {}'.format(self._search, criteria)
+
         try:
             messages = self._server.gmail_search(criteria)
         except:

--- a/lpf.py
+++ b/lpf.py
@@ -10,17 +10,24 @@ __credits__   = ['Claudio Matsuoka', 'Alexandre Possebom']
 
 import os
 import sys
+import argparse
 
 from lostphotosfound.server import Server
 from lostphotosfound.config import Config
 
 if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-S', '--search', type=str, help='specify additional search criteria')
+    args = parser.parse_args()
+
     config = Config()
     host = config.get('host')
     username = config.get('username')
     password = config.get('password')
+    search = args.search
 
-    imap = Server(host, username, password, debug=os.getenv('DEBUG', False))
+    imap = Server(host, username, password, search=search, debug=os.getenv('DEBUG', False))
     imap.lostphotosfound()
 
     print 'All done, see directory ~/LostPhotosFound for all the treasure we found for you :-)'


### PR DESCRIPTION
Allow the user to specify extra search filters such as 'from:' or 'subject:'. This is useful when a user wants to retrieve images from a specific subset of emails, but it may adversely affect new downloads with a different search criteria because the index was already updated. Perhaps a new command-line parameters such as --reset (to erase hashes and indexes) could solve this problem.