### PR TITLE
Don't crash on encoding errors and add option to ignore index

### DIFF
--- a/lostphotosfound/server.py
+++ b/lostphotosfound/server.py
@@ -32,7 +32,7 @@ class Server:
     fetch all attachments of the mails matching the criteria and
     save them locally with a timestamp
     """
-    def __init__(self, host, username, password, search='', debug=False):
+    def __init__(self, host, username, password, search='', debug=False, use_index=True):
         """
         Server class __init__ which expects an IMAP host to connect to
 
@@ -63,6 +63,9 @@ class Server:
 
 	# additional email filtering using Gmail search syntax
 	self._search = search
+
+	# ignore index file
+	self._use_index = use_index
 
         self._username = username
         self._login(username, password)
@@ -225,7 +228,7 @@ class Server:
             msgid = str(idfetched[idfetched.keys()[0]]['X-GM-MSGID'])
 
             # mail has been processed in the past, skip it
-            if msgid in self._index.keys():
+            if self._use_index and msgid in self._index.keys():
                 print 'Skipping X-GM-MSDID %s' % (msgid)
                 continue
 

--- a/lostphotosfound/server.py
+++ b/lostphotosfound/server.py
@@ -236,7 +236,12 @@ class Server:
             msgdata = self._server.fetch([msg], ['RFC822'])
 
             for data in msgdata:
-                mail = message_from_string(msgdata[data]['RFC822'].encode('utf-8'))
+                try:
+                    mail = message_from_string(msgdata[data]['RFC822'].encode('utf-8'))
+                except UnicodeDecodeError:
+                    print("Warning: can't encode message data to UTF-8")
+                    mail = message_from_string(msgdata[data]['RFC822'])
+
                 if mail.get_content_maintype() != 'multipart':
                     continue
 

--- a/lpf.py
+++ b/lpf.py
@@ -19,8 +19,8 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--no-index', help='ignore retrieved email index', action='store_true')
+    parser.add_argument('-F', '--folders', help='create folders for email senders', action='store_true')
     parser.add_argument('-S', '--search', type=str, help='specify additional search criteria')
-    parser.add_argument('--sort-by-sender', help='sort retrieved images by sender', action='store_true')
     args = parser.parse_args()
 
     config = Config()
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     password = config.get('password')
     search = args.search
     use_index = not args.no_index
-    use_folders = args.sort_by_sender
+    use_folders = args.folders
 
     imap = Server(host, username, password, search=search, debug=os.getenv('DEBUG', False),
                   use_index=use_index, use_folders=use_folders)

--- a/lpf.py
+++ b/lpf.py
@@ -18,6 +18,7 @@ from lostphotosfound.config import Config
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
+    parser.add_argument('-n', '--no-index', help='ignore retrieved email index', action='store_true')
     parser.add_argument('-S', '--search', type=str, help='specify additional search criteria')
     args = parser.parse_args()
 
@@ -26,8 +27,10 @@ if __name__ == "__main__":
     username = config.get('username')
     password = config.get('password')
     search = args.search
+    use_index = not args.no_index
 
-    imap = Server(host, username, password, search=search, debug=os.getenv('DEBUG', False))
+    imap = Server(host, username, password, search=search, debug=os.getenv('DEBUG', False),
+                  use_index=use_index)
     imap.lostphotosfound()
 
     print 'All done, see directory ~/LostPhotosFound for all the treasure we found for you :-)'

--- a/lpf.py
+++ b/lpf.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--no-index', help='ignore retrieved email index', action='store_true')
     parser.add_argument('-S', '--search', type=str, help='specify additional search criteria')
+    parser.add_argument('--sort-by-sender', help='sort retrieved images by sender', action='store_true')
     args = parser.parse_args()
 
     config = Config()
@@ -28,9 +29,10 @@ if __name__ == "__main__":
     password = config.get('password')
     search = args.search
     use_index = not args.no_index
+    use_folders = args.sort_by_sender
 
     imap = Server(host, username, password, search=search, debug=os.getenv('DEBUG', False),
-                  use_index=use_index)
+                  use_index=use_index, use_folders=use_folders)
     imap.lostphotosfound()
 
     print 'All done, see directory ~/LostPhotosFound for all the treasure we found for you :-)'

--- a/lpf.py
+++ b/lpf.py
@@ -18,7 +18,7 @@ from lostphotosfound.config import Config
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-n', '--no-index', help='ignore retrieved email index', action='store_true')
+    parser.add_argument('--no-index', help='ignore retrieved email index', action='store_true')
     parser.add_argument('-S', '--search', type=str, help='specify additional search criteria')
     args = parser.parse_args()
 


### PR DESCRIPTION
We have two new features here: parameter -n to ignore the index file (useful for development and debugging, but it also may be useful in real cases when -S is specified), and a fix/workaround for UTF-8 encoding crashes. Probably the best way to deal with the encoding problem is to decode/encode each part separately, but this quick fix allow us to actually retrieve all images in the mailbox without crashing if we find an email with parts using different encodings.